### PR TITLE
Update git hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint shell scripts
+
+on: push
+
+jobs:
+  lint:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@1.0.0
+        with:
+          scandir: 'store/.git_template/hooks'

--- a/store/.git_template/hooks/ctags.sh
+++ b/store/.git_template/hooks/ctags.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd `git rev-parse --git-dir`/..
+cd "$(git rev-parse --git-dir)/.."
 trap 'rm -f .git/$$.tags' EXIT
 ctags -f .git/$$.tags
 mv .git/$$.tags .git/tags

--- a/store/.git_template/hooks/post-checkout
+++ b/store/.git_template/hooks/post-checkout
@@ -1,2 +1,5 @@
 #!/bin/bash
-.git/hooks/ctags.sh >/dev/null 2>&1 &
+
+set -eo pipefail
+
+setpid .git/hooks/ctags.sh >/dev/null 2>&1

--- a/store/.git_template/hooks/post-commit
+++ b/store/.git_template/hooks/post-commit
@@ -1,2 +1,5 @@
 #!/bin/bash
-.git/hooks/ctags.sh >/dev/null 2>&1 &
+
+set -eo pipefail
+
+setpid .git/hooks/ctags.sh >/dev/null 2>&1

--- a/store/.git_template/hooks/post-merge
+++ b/store/.git_template/hooks/post-merge
@@ -1,2 +1,5 @@
 #!/bin/bash
-.git/hooks/ctags.sh >/dev/null 2>&1 &
+
+set -eo pipefail
+
+setpid .git/hooks/ctags.sh >/dev/null 2>&1


### PR DESCRIPTION
## Adds

* GitHub action to use https://github.com/ludeeus/action-shellcheck/ to check Git hook scripts.

* Use of `setpid` on `ctags` scripts to allow them to run after Vim has killed the process group.