### PR TITLE
Reinstate & to ctags hooks call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: lint
+lint:
+	shellcheck2 store/.git_template/hooks/*

--- a/store/.git_template/hooks/post-checkout
+++ b/store/.git_template/hooks/post-checkout
@@ -2,4 +2,4 @@
 
 set -eo pipefail
 
-setsid .git/hooks/ctags.sh >/dev/null 2>&1
+setsid .git/hooks/ctags.sh >/dev/null 2>&1 &

--- a/store/.git_template/hooks/post-commit
+++ b/store/.git_template/hooks/post-commit
@@ -2,4 +2,4 @@
 
 set -eo pipefail
 
-setsid .git/hooks/ctags.sh >/dev/null 2>&1
+setsid .git/hooks/ctags.sh >/dev/null 2>&1 &

--- a/store/.git_template/hooks/post-merge
+++ b/store/.git_template/hooks/post-merge
@@ -2,4 +2,4 @@
 
 set -eo pipefail
 
-setsid .git/hooks/ctags.sh >/dev/null 2>&1
+setsid .git/hooks/ctags.sh >/dev/null 2>&1 &

--- a/store/.git_template/hooks/post-rewrite
+++ b/store/.git_template/hooks/post-rewrite
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+set -eo pipefail
+
 case "$1" in
   rebase) exec .git/hooks/post-merge ;;
 esac


### PR DESCRIPTION
This allows `git` in shell to background the ctags process.