### PR TITLE
Fix hooks again

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Vim is configured to use [Plug](https://github.com/junegunn/vim-plug). After
 running `stow`, then:
 
 ```sh
-$ curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
 You can find out more about [my Vim configuration in this

--- a/store/.git_template/hooks/ctags.sh
+++ b/store/.git_template/hooks/ctags.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+
+set -eo pipefail
 
 cd "$(git rev-parse --git-dir)/.."
 trap 'rm -f .git/$$.tags' EXIT

--- a/store/.git_template/hooks/post-checkout
+++ b/store/.git_template/hooks/post-checkout
@@ -2,4 +2,4 @@
 
 set -eo pipefail
 
-setsid .git/hooks/ctags.sh >/dev/null 2>&1 &
+setsid .git/hooks/wrapped_ctags.sh

--- a/store/.git_template/hooks/post-commit
+++ b/store/.git_template/hooks/post-commit
@@ -2,4 +2,4 @@
 
 set -eo pipefail
 
-setsid .git/hooks/ctags.sh >/dev/null 2>&1 &
+setsid .git/hooks/wrapped_ctags.sh

--- a/store/.git_template/hooks/post-merge
+++ b/store/.git_template/hooks/post-merge
@@ -2,4 +2,4 @@
 
 set -eo pipefail
 
-setsid .git/hooks/ctags.sh >/dev/null 2>&1 &
+setsid .git/hooks/wrapped_ctags.sh

--- a/store/.git_template/hooks/wrapped_ctags.sh
+++ b/store/.git_template/hooks/wrapped_ctags.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eo pipefail
+
+.git/hooks/ctags.sh > /tmp/ctags.log 2>&1 &


### PR DESCRIPTION
Add wrapper so that `setsid` can be used to allow `ctags` to run after a commit via Vim. But also keep `&` backgrounding so that committing / changing branches from shell doesn't cause delay.